### PR TITLE
Merge akalswl14/develop to develop

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -12,6 +12,7 @@ import { config } from 'ormconfig';
 import { TechstackModule } from './techstack/techstack.module';
 import { TaskModule } from './task/task.module';
 import { GithubModule } from './github/github.module';
+import { MemoirModule } from './memoir/memoir.module';
 
 @Module({
   imports: [
@@ -26,6 +27,7 @@ import { GithubModule } from './github/github.module';
     TechstackModule,
     TaskModule,
     GithubModule,
+    MemoirModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/dto/github.dto.ts
+++ b/src/dto/github.dto.ts
@@ -3,21 +3,24 @@ import {
   IsArray,
   IsBoolean,
   IsEnum,
+  IsNumber,
   IsNumberString,
   IsString,
 } from 'class-validator';
 import { ProcessStatus } from 'src/entities/enum';
+import { MonthlyReport } from 'src/entities/monthly-report.entity';
 import { Entity } from 'typeorm';
+import { memoirThumbnail } from './memoir.dto';
 
 @Entity()
 export class repositoryDto {
-  @IsNumberString()
+  @IsNumber()
   @ApiProperty({
     description: 'github Repository ID. 서비스 DB 내의 Repository ID 아님.',
     required: true,
     nullable: true,
   })
-  gitRepoId: string;
+  gitRepoId: number;
 
   @IsString()
   @ApiProperty({ description: 'Repository 이름', required: true })
@@ -65,14 +68,15 @@ export class reportLogDto {
   })
   reportStatus: ProcessStatus | null;
 
-  @IsString()
+  @IsNumber()
   @IsArray()
   @ApiProperty({
-    description: '사용된 Repository 이름',
+    description: '사용된 Repository Git ID 들',
     required: true,
     isArray: true,
+    type: 'bigint',
   })
-  repoNames: string[];
+  repoIds: string[];
 
   @IsString()
   @ApiProperty({
@@ -109,4 +113,84 @@ export class requestRepoInputDto {
     required: true,
   })
   gitAccessToken: string;
+}
+
+@Entity()
+export class languageToTaskDto {
+  @IsNumberString()
+  @ApiProperty({
+    description: '(희망) 직무 Task ID',
+    required: true,
+    type: 'bigint',
+  })
+  taskId: string;
+
+  @IsString()
+  @ApiProperty({
+    description: '(희망) 직무 Task 이름',
+    required: true,
+  })
+  taskName: string;
+
+  @IsNumberString()
+  @ApiProperty({
+    description: '해당 테크스택 TechStack ID',
+    required: true,
+    type: 'bigint',
+  })
+  techstackId: string;
+
+  @IsString()
+  @ApiProperty({
+    description: '해당 테크스택 TechStack 이름',
+    required: true,
+  })
+  techstackName: string;
+
+  @IsNumberString()
+  @ApiProperty({
+    description: '해당 언어 Language ID',
+    required: true,
+    type: 'bigint',
+  })
+  languageId: string;
+
+  @IsString()
+  @ApiProperty({
+    description: '해당 언어 Language 이름',
+    required: true,
+  })
+  languageName: string;
+}
+
+export type monthlyReportContents = Omit<
+  MonthlyReport,
+  'user' | 'repoIds' | 'updatedAt'
+>;
+
+@Entity()
+export class monthlyReportThumbnail {
+  @IsEnum(ProcessStatus)
+  @ApiProperty({
+    description:
+      '분석 결과 상태값. 이전에 생성된 분석 결과가 없는 경우 현재 분석 상태를 반환함\n만약 Repository를 선택하지 않아 요청된 상태가 아니거나, 이전 분석 결과가 있을 경우에는 null을 반환함.\nrequest : 분석 요청 / onprogress : 분석 중 / fail : 실패 / success : 분석 성공 및 결과 생성',
+    required: true,
+    nullable: true,
+  })
+  status: ProcessStatus;
+
+  @ApiProperty({
+    description: '분석 결과. 반환할 결과가 없을 경우 null',
+    required: true,
+    nullable: true,
+  })
+  contents: monthlyReportContents | null;
+
+  @ApiProperty({
+    description:
+      '분석 결과에 연결된 월간회고록 Memoir. 반환할 결과가 없을 경우 null',
+    required: true,
+    nullable: true,
+  })
+  memoir: memoirThumbnail | null;
 }

--- a/src/dto/memoir.dto.ts
+++ b/src/dto/memoir.dto.ts
@@ -1,0 +1,65 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsArray,
+  IsBoolean,
+  IsDate,
+  IsEnum,
+  IsNumber,
+  IsNumberString,
+  IsString,
+} from 'class-validator';
+import { Entity } from 'typeorm';
+
+@Entity()
+export class memoirThumbnail {
+  @IsNumberString()
+  @ApiProperty({
+    description: '월간 분석 결과에 해당하는 회고록 ID',
+    required: true,
+  })
+  id: string;
+
+  @IsString()
+  @ApiProperty({
+    description: '회고록 내용',
+    required: true,
+    nullable: true,
+  })
+  description: string;
+
+  @IsDate()
+  @ApiProperty({
+    description: '회고록 최종수정일',
+    required: true,
+  })
+  updatedAt: Date;
+}
+
+@Entity()
+export class inputMemoirDto {
+  @IsNumberString()
+  @ApiProperty({
+    description:
+      '월간 분석 결과에 해당하는 회고록 ID. \nMonthlyReport 페이지를 통해, 회고록을 최초 생성할 경우 ID가 없을 때에는 null 값으로 보내고, monthlyReport ID는 not null로 전달해야함.',
+    required: true,
+    nullable: true,
+  })
+  id: string;
+
+  @IsString()
+  @ApiProperty({
+    description: '등록할 회고록 내용',
+    required: true,
+    nullable: false,
+  })
+  description: string;
+
+  @IsNumberString()
+  @ApiProperty({
+    description:
+      '월간 분석 결과 ID. \nMonthlyReport 페이지를 통해, 회고록을 최초 생성할 경우 ID가 없을 때에는 id property를 null 값으로 보내고, monthlyReport ID propperty는 not null로 전달해야함.',
+    required: true,
+    nullable: true,
+  })
+  monthlyReportId: string;
+}

--- a/src/entities/language.entity.ts
+++ b/src/entities/language.entity.ts
@@ -2,14 +2,22 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  OneToMany,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
+import { StackToLanguage } from './stack-to-language.entity';
 
 @Entity('language')
 export class Language {
   @PrimaryGeneratedColumn({ type: 'bigint' })
   id: string;
+
+  @OneToMany(
+    () => StackToLanguage,
+    (stackToLanguage) => stackToLanguage.language,
+  )
+  stackToLanguages: StackToLanguage[];
 
   @Column({ length: '255' })
   languageName: string;

--- a/src/entities/memoir.entity.ts
+++ b/src/entities/memoir.entity.ts
@@ -6,8 +6,10 @@ import {
   UpdateDateColumn,
   JoinColumn,
   OneToOne,
+  ManyToOne,
 } from 'typeorm';
 import { MonthlyReport } from './monthly-report.entity';
+import { User } from './user.entity';
 
 @Entity('memoir')
 export class Memoir {
@@ -17,6 +19,9 @@ export class Memoir {
   @OneToOne(() => MonthlyReport, { nullable: true })
   @JoinColumn()
   monthlyReport: MonthlyReport;
+
+  @ManyToOne(() => User, (user) => user.memoirs, { nullable: false })
+  user: User;
 
   @Column({ type: 'text', nullable: true })
   description: string;

--- a/src/entities/monthly-report.entity.ts
+++ b/src/entities/monthly-report.entity.ts
@@ -16,8 +16,8 @@ export class MonthlyReport {
   @ManyToOne(() => User, (user) => user.monthlyReports, { nullable: false })
   user: User;
 
-  @Column({ type: 'bigint' })
-  repoIds: bigint[];
+  @Column({ type: 'bigint', array: true })
+  repoIds: string[];
 
   @Column({ nullable: true, default: 0 })
   commitNum: number;
@@ -37,14 +37,20 @@ export class MonthlyReport {
   @Column({ type: 'json' })
   languageDetail: string;
 
+  @Column({ nullable: true, type: 'bigint' })
+  stackId: string;
+
   @Column({ length: '255', nullable: true })
   stackName: string;
 
   @Column({ length: '255', nullable: true })
   stackLanguage: string;
 
+  @Column({ nullable: true, type: 'bigint' })
+  stackTaskId: string;
+
   @Column({ length: '255', nullable: true })
-  stackTask: string;
+  stackTaskName: string;
 
   @CreateDateColumn({ type: 'timestamp without time zone' })
   createdAt: Date;

--- a/src/entities/stack-to-language.entity.ts
+++ b/src/entities/stack-to-language.entity.ts
@@ -1,0 +1,38 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { Techstack } from './techstack.entity';
+import { Language } from './language.entity';
+
+@Entity('stack_to_language')
+export class StackToLanguage {
+  @PrimaryGeneratedColumn({ type: 'bigint' })
+  id: string;
+
+  @ManyToOne(() => Techstack, (techstack) => techstack.stackToLanguages, {
+    nullable: false,
+  })
+  techstack: Techstack;
+
+  @ManyToOne(() => Language, (language) => language.stackToLanguages, {
+    nullable: false,
+  })
+  language: Language;
+
+  @Column()
+  techstackId: string;
+
+  @Column()
+  languageId: string;
+
+  @CreateDateColumn({ type: 'timestamp without time zone' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ type: 'timestamp without time zone' })
+  updatedAt: Date;
+}

--- a/src/entities/techstack.entity.ts
+++ b/src/entities/techstack.entity.ts
@@ -9,16 +9,18 @@ import {
   UpdateDateColumn,
 } from 'typeorm';
 import { Language } from './language.entity';
+import { StackToLanguage } from './stack-to-language.entity';
 import { TrendStack } from './trend-stack.entity';
 
 @Entity('techstack')
 export class Techstack {
   @PrimaryGeneratedColumn({ type: 'bigint' })
   id: string;
-
-  @ManyToMany(() => Language)
-  @JoinTable()
-  languages: Language[];
+  @OneToMany(
+    () => StackToLanguage,
+    (stackToLanguage) => stackToLanguage.techstack,
+  )
+  stackToLanguages: StackToLanguage[];
 
   @OneToMany(() => TrendStack, (trendStack) => trendStack.techstack)
   trendStacks: TrendStack[];

--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -17,6 +17,7 @@ import { Portfolio } from './porfolio.entity';
 import { MonthlyReport } from './monthly-report.entity';
 import { WishRecruit } from './wish-recruit.entity';
 import { WishTask } from './wish-task.entity';
+import { Memoir } from './memoir.entity';
 
 @Entity('user')
 export class User {
@@ -70,6 +71,9 @@ export class User {
 
   @OneToMany(() => MonthlyReport, (monthlyReport) => monthlyReport.user)
   monthlyReports: MonthlyReport[];
+
+  @OneToMany(() => Memoir, (memoir) => memoir.user)
+  memoirs: Memoir[];
 
   @OneToMany(() => WishRecruit, (wishRecruit) => wishRecruit.user)
   wishRecruits: WishRecruit[];

--- a/src/github/github.controller.ts
+++ b/src/github/github.controller.ts
@@ -9,6 +9,7 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import {
+  monthlyReportThumbnail,
   reportLogDto,
   repositoryDto,
   repositoryThumbnailDto,
@@ -71,12 +72,24 @@ export class GithubController {
   @UseGuards(AuthGuard('jwt'))
   async createManualReport(
     @Req() { user: { userId } },
-  ): // ): Promise<reportLogDto[]> {
-  Promise<any[]> {
+  ): Promise<reportLogDto[]> {
     return this.githubsService.createManualReport();
   }
 
-  // async getMonthlyReport(@Req() {user:{userId}}){
-  //   return {reportStatus:enum,data:{}}
-  // }
+  @Get('report')
+  @ApiOperation({
+    summary: '유저 monthly report 반환 API',
+    description: 'github repository 분석 결과 페이지의 분석 결과를 반환함.',
+  })
+  @ApiOkResponse({
+    description: '현재 분석 상태와, 해당하는 분석 결과값을 반환함.',
+    type: monthlyReportThumbnail,
+    isArray: false,
+  })
+  @UseGuards(AuthGuard('jwt'))
+  async getMonthlyReport(
+    @Req() { user: { userId } },
+  ): Promise<monthlyReportThumbnail> {
+    return this.githubsService.getMonthlyReport(userId);
+  }
 }

--- a/src/github/github.module.ts
+++ b/src/github/github.module.ts
@@ -2,10 +2,16 @@ import { HttpModule } from '@nestjs/axios';
 import { Module } from '@nestjs/common';
 import { PassportModule } from '@nestjs/passport';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { Language } from 'src/entities/language.entity';
+import { Memoir } from 'src/entities/memoir.entity';
 import { MonthlyReport } from 'src/entities/monthly-report.entity';
+import { OauthInfo } from 'src/entities/oauth-info.entity';
 import { ReportLog } from 'src/entities/report-log.entity';
 import { Repository } from 'src/entities/repository.entity';
+import { StackToLanguage } from 'src/entities/stack-to-language.entity';
+import { TrendStack } from 'src/entities/trend-stack.entity';
 import { User } from 'src/entities/user.entity';
+import { WishTask } from 'src/entities/wish-task.entity';
 import { GithubController } from './github.controller';
 import { GithubService } from './github.service';
 
@@ -13,7 +19,18 @@ import { GithubService } from './github.service';
   imports: [
     HttpModule,
     PassportModule,
-    TypeOrmModule.forFeature([Repository, User, ReportLog, MonthlyReport]),
+    TypeOrmModule.forFeature([
+      Repository,
+      User,
+      ReportLog,
+      MonthlyReport,
+      OauthInfo,
+      WishTask,
+      TrendStack,
+      Language,
+      StackToLanguage,
+      Memoir,
+    ]),
   ],
   controllers: [GithubController],
   providers: [GithubService],

--- a/src/memoir/memoir.controller.ts
+++ b/src/memoir/memoir.controller.ts
@@ -1,0 +1,56 @@
+import { Body, Controller, Get, Post, Req, UseGuards } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiCreatedResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
+import { inputMemoirDto, memoirThumbnail } from 'src/dto/memoir.dto';
+import { MemoirService } from './memoir.service';
+
+@ApiTags('memoir 정보 API')
+@ApiBearerAuth()
+@Controller('memoir')
+export class MemoirController {
+  constructor(private readonly memoirsService: MemoirService) {}
+
+  @Get('')
+  @ApiOperation({
+    summary: '유저 memoir 목록 반환 API',
+    description: '회고록 Memoir 목록페이지의 회고록 목록을 반환함.',
+  })
+  @ApiOkResponse({
+    description: '유저의 회고록 Memoir 목록을 반환함',
+    type: memoirThumbnail,
+    isArray: true,
+  })
+  @UseGuards(AuthGuard('jwt'))
+  async getMemoirs(@Req() { user: { userId } }): Promise<memoirThumbnail[]> {
+    return this.memoirsService.getMemoirs(userId);
+  }
+
+  @Post('')
+  @ApiOperation({
+    summary: '회고록 반영 ( 수정 / 생성 ) API',
+    description: '회고록을 수정, 생성함',
+  })
+  @ApiBody({
+    type: inputMemoirDto,
+    description:
+      '반영할 회고록 Memoir 정보.\n회고록을 새로 생성하는 경우, monthlyReportId가 주어져야하고, 수정하는 경우에는 id (memoirId)가 주어져야합니다.',
+  })
+  @ApiCreatedResponse({
+    type: Boolean,
+    description: '성공적으로 반영됨. ',
+  })
+  @UseGuards(AuthGuard('jwt'))
+  async updateMemoir(
+    @Req() { user: { userId } },
+    @Body('inputMemoir') inputMemoir: inputMemoirDto,
+  ): Promise<Boolean> {
+    return this.memoirsService.updateMemoir(userId, inputMemoir);
+  }
+}

--- a/src/memoir/memoir.module.ts
+++ b/src/memoir/memoir.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { PassportModule } from '@nestjs/passport';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Memoir } from 'src/entities/memoir.entity';
+import { MonthlyReport } from 'src/entities/monthly-report.entity';
+import { MemoirController } from './memoir.controller';
+import { MemoirService } from './memoir.service';
+
+@Module({
+  imports: [PassportModule, TypeOrmModule.forFeature([MonthlyReport, Memoir])],
+  controllers: [MemoirController],
+  providers: [MemoirService],
+})
+export class MemoirModule {}

--- a/src/memoir/memoir.service.ts
+++ b/src/memoir/memoir.service.ts
@@ -1,0 +1,65 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { inputMemoirDto, memoirThumbnail } from 'src/dto/memoir.dto';
+import { Memoir } from 'src/entities/memoir.entity';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class MemoirService {
+  constructor(
+    @InjectRepository(Memoir)
+    private readonly memoirsRepository: Repository<Memoir>,
+  ) {}
+
+  async getMemoirs(userId: string): Promise<memoirThumbnail[]> {
+    const memoirList = await this.memoirsRepository.find({
+      where: { user: { id: userId } },
+      order: { createdAt: 'DESC' },
+    });
+    return memoirList.map(({ id, description, updatedAt }) => ({
+      id,
+      description,
+      updatedAt,
+    }));
+  }
+
+  async updateMemoir(
+    userId: string,
+    inputMemoir: inputMemoirDto,
+  ): Promise<Boolean> {
+    const { id: memoirId, monthlyReportId, description } = inputMemoir;
+    if (memoirId) {
+      // 기존에 회고록이 있고, 수정하는 경우
+      const checkMemoir = await this.memoirsRepository.findOne({
+        where: { id: memoirId, user: { id: userId } },
+      });
+      if (!checkMemoir) {
+        // 회고록 조회 실패 - 없는 회고록 이거나, 해당 회고록의 user가 아닌 경우거나,
+        throw new NotFoundException({
+          description: `조회할 수 없는 Memoir입니다.`,
+        });
+      }
+      await this.memoirsRepository.update({ id: memoirId }, { description });
+      return true;
+    } else if (monthlyReportId) {
+      // 회고록을 새로 생성하는 경우
+      await this.memoirsRepository.save(
+        this.memoirsRepository.create({
+          user: { id: userId },
+          monthlyReport: { id: monthlyReportId },
+          description,
+        }),
+      );
+      return true;
+    } else {
+      // 잘못된 input
+      throw new BadRequestException({
+        description: `잘못된 요청입니다.`,
+      });
+    }
+  }
+}

--- a/src/middleware/github.strategy.ts
+++ b/src/middleware/github.strategy.ts
@@ -12,7 +12,7 @@ export class GithubStrategy extends PassportStrategy(Strategy, 'github') {
       clientID: process.env.GITHUB_CLIENT_ID,
       clientSecret: process.env.GITHUB_SECRET,
       callbackURL: 'http://localhost:3000/auth/github/callback',
-      scope: ['user:email'],
+      scope: ['user:email', 'repo'],
     });
   }
 

--- a/src/migrations/1653189587945-Add stack-to-language Entity.ts
+++ b/src/migrations/1653189587945-Add stack-to-language Entity.ts
@@ -1,0 +1,18 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class AddStackToLanguageEntity1653189587945 implements MigrationInterface {
+    name = 'AddStackToLanguageEntity1653189587945'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "stack_to_language" ("id" BIGSERIAL NOT NULL, "techstackId" bigint NOT NULL, "languageId" bigint NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "PK_0efa630da21e31bd1877d712868" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`ALTER TABLE "stack_to_language" ADD CONSTRAINT "FK_9bb75e5161178437c1de5f2098f" FOREIGN KEY ("techstackId") REFERENCES "techstack"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "stack_to_language" ADD CONSTRAINT "FK_3cb94e3306ccc74b1787832152b" FOREIGN KEY ("languageId") REFERENCES "language"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "stack_to_language" DROP CONSTRAINT "FK_3cb94e3306ccc74b1787832152b"`);
+        await queryRunner.query(`ALTER TABLE "stack_to_language" DROP CONSTRAINT "FK_9bb75e5161178437c1de5f2098f"`);
+        await queryRunner.query(`DROP TABLE "stack_to_language"`);
+    }
+
+}

--- a/src/migrations/1653189838764-Delete Techstack to Language Automatically generate Jointable.ts
+++ b/src/migrations/1653189838764-Delete Techstack to Language Automatically generate Jointable.ts
@@ -1,0 +1,11 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class DeleteTechstackToLanguageAutomaticallyGenerateJointable1653189838764
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "techstack_languages_language"`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {}
+}

--- a/src/migrations/1653205177579-Add columns on monthly_report.ts
+++ b/src/migrations/1653205177579-Add columns on monthly_report.ts
@@ -1,0 +1,20 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class AddColumnsOnMonthlyReport1653205177579 implements MigrationInterface {
+    name = 'AddColumnsOnMonthlyReport1653205177579'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "monthly_report" DROP COLUMN "stackTask"`);
+        await queryRunner.query(`ALTER TABLE "monthly_report" ADD "stackId" bigint`);
+        await queryRunner.query(`ALTER TABLE "monthly_report" ADD "stackTaskId" bigint`);
+        await queryRunner.query(`ALTER TABLE "monthly_report" ADD "stackTaskName" character varying(255)`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "monthly_report" DROP COLUMN "stackTaskName"`);
+        await queryRunner.query(`ALTER TABLE "monthly_report" DROP COLUMN "stackTaskId"`);
+        await queryRunner.query(`ALTER TABLE "monthly_report" DROP COLUMN "stackId"`);
+        await queryRunner.query(`ALTER TABLE "monthly_report" ADD "stackTask" character varying(255)`);
+    }
+
+}

--- a/src/migrations/1653212511642-Fix column type on monthly_report.ts
+++ b/src/migrations/1653212511642-Fix column type on monthly_report.ts
@@ -1,0 +1,16 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class FixColumnTypeOnMonthlyReport1653212511642 implements MigrationInterface {
+    name = 'FixColumnTypeOnMonthlyReport1653212511642'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "monthly_report" DROP COLUMN "repoIds"`);
+        await queryRunner.query(`ALTER TABLE "monthly_report" ADD "repoIds" bigint array NOT NULL`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "monthly_report" DROP COLUMN "repoIds"`);
+        await queryRunner.query(`ALTER TABLE "monthly_report" ADD "repoIds" bigint NOT NULL`);
+    }
+
+}

--- a/src/migrations/1653221785669-Fix columns on User and Memoir for Memoir.ts
+++ b/src/migrations/1653221785669-Fix columns on User and Memoir for Memoir.ts
@@ -1,0 +1,16 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class FixColumnsOnUserAndMemoirForMemoir1653221785669 implements MigrationInterface {
+    name = 'FixColumnsOnUserAndMemoirForMemoir1653221785669'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "memoir" ADD "userId" bigint NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "memoir" ADD CONSTRAINT "FK_0dec530064859fcb8fe5fea1d95" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "memoir" DROP CONSTRAINT "FK_0dec530064859fcb8fe5fea1d95"`);
+        await queryRunner.query(`ALTER TABLE "memoir" DROP COLUMN "userId"`);
+    }
+
+}

--- a/src/recruit/recruit.service.ts
+++ b/src/recruit/recruit.service.ts
@@ -89,21 +89,17 @@ export class RecruitService {
       where: { user: { id: userId }, recruit: { id: recruitId } },
     });
     if (wishCnt > 0) {
-      await getConnection()
-        .createQueryBuilder()
+      await this.wishRecruitsRepository
+        .createQueryBuilder('wishRecruit')
         .delete()
-        .from(WishRecruit)
-        .where('userId = :userId AND recruitId = :recruitId', {
-          userId,
-          recruitId,
-        })
+        .where('userId = :userId', { userId })
+        .andWhere('recruitId = :recruitId', { recruitId })
         .execute();
       return false;
     } else {
-      await getConnection()
-        .createQueryBuilder()
+      await this.wishRecruitsRepository
+        .createQueryBuilder('wishRecruit')
         .insert()
-        .into(WishRecruit)
         .values({ user: { id: userId }, recruit: { id: recruitId } })
         .execute();
       return true;

--- a/src/recruit/recruit.service.ts
+++ b/src/recruit/recruit.service.ts
@@ -1,4 +1,8 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import {
   recruitDetailDto,
@@ -37,6 +41,8 @@ export class RecruitService {
       select: ['taskId'],
       order: { priority: 'ASC' },
     });
+    if (wishTasks.length == 0)
+      throw new ForbiddenException(`선택한 관심 직무가 없습니다.`);
     const taskIdList = wishTasks.map(({ taskId }) => taskId);
 
     const [taskRecruits, totalRecruitNum] = await this.recruitsRepository
@@ -112,8 +118,8 @@ export class RecruitService {
       select: ['taskId'],
       order: { priority: 'ASC' },
     });
-    if (!wishTaskResult)
-      throw new NotFoundException(`wish_task 결과가 없습니다`);
+    if (wishTaskResult.length == 0)
+      throw new ForbiddenException(`선택한 관심 직무가 없습니다.`);
     // 사용자의 희망 직무별 trendstack 찾아서 recruit 데이터 반환
     for (const { taskId: wishTaskId } of wishTaskResult) {
       const trendStackResult = await this.trendStacksRepository.find({

--- a/src/testdata/testdata.controller.ts
+++ b/src/testdata/testdata.controller.ts
@@ -152,4 +152,21 @@ export class TestdataController {
   async putTrendStackData(@Body() inputData: any): Promise<Boolean> {
     return this.testDataService.putTrendStackData(inputData);
   }
+
+  @Post('extratrendstack')
+  @ApiOperation({
+    summary: 'TrendStack 추가 매뉴얼 데이터 삽입 API',
+    description: '매뉴얼적으로 추가한 TrendStack 데이터를 삽입함',
+  })
+  @ApiBody({
+    type: 'json',
+    description: 'Task 별 연관 Stack 추가 데이터',
+  })
+  @ApiOkResponse({
+    description: '성공일 경우 True, 실패일 경우 False',
+    type: Boolean,
+  })
+  async putExtraTrendStackData(@Body() inputData: any): Promise<Boolean> {
+    return this.testDataService.putExtraTrendStackData(inputData);
+  }
 }

--- a/src/testdata/testdata.module.ts
+++ b/src/testdata/testdata.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Language } from 'src/entities/language.entity';
 import { Recruit } from 'src/entities/recruit.entity';
+import { StackToLanguage } from 'src/entities/stack-to-language.entity';
 import { Task } from 'src/entities/task.entity';
 import { Techstack } from 'src/entities/techstack.entity';
 import { TrendStack } from 'src/entities/trend-stack.entity';
@@ -18,6 +19,7 @@ import { TestdataService } from './testdata.service';
       Techstack,
       Language,
       TrendStack,
+      StackToLanguage,
     ]),
   ],
   controllers: [TestdataController],

--- a/src/testdata/testdata.service.ts
+++ b/src/testdata/testdata.service.ts
@@ -336,4 +336,20 @@ export class TestdataService {
       return null;
     }
   }
+
+  async putExtraTrendStackData(testData: any): Promise<Boolean> {
+    const insertData = [];
+    for (const { taskId, techstackId, num } of testData) {
+      insertData.push(
+        this.trendStacksRepository.create({
+          task: { id: taskId },
+          techstack: { id: techstackId },
+          priority: num,
+        }),
+      );
+    }
+    const result = await this.trendStacksRepository.insert(insertData);
+    if (!result) return false;
+    return true;
+  }
 }


### PR DESCRIPTION
- getTodayRecruits API 수정 : wishTask 없는 경우의 에러 핸들링
- getRecommendRecruits API 수정 : wishTask 없는 경우의 에러 핸들링
- Language,Memoir,MonthlyReport,TechStack,User 엔티티 수정
- StackToLanguage 엔티티 추가
- Github Auth Strategy 수정
	- Github 로그인시의 Oauth App 허가 발급시에, 기존에는 mail 권한만 있었는데, 이를 Repository 권한까지 받도록 수정함
- toggleWishRecruit API 리팩토링
	- getConnection()이 Typeorm에서 deprectated되어서, Repository + QueryBuilder로 쿼리 날리도록 변경함
- putExtraTrendStackData Test API 추가
	- TrendStack의 추가 데이터를 삽입하는 Test API 추가
- putStackToLanguageData Test API 변경
	- putStackToLanguageData API를 StackToLanguage 엔티티가 변경됨에 따라 개선함
- createManualReport API 수정
- getMonthlyReport API 추가
- getMemoirs API 추가
- updateMemoir API 추가

Solved Issue
- Fixed #4 